### PR TITLE
Show base damage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ libs/
 *#
 
 # IDEs
+.idea/
 .classpath
 .project
 .settings

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,9 @@ minecraft {
 	version = minecraft_version + "-" + forge_version
 }
 
+version = "${minecraft_version}-${tictooltips_version}"
 group = project.projectDir.name.toLowerCase()
-archivesBaseName = project.projectDir.name + "-mc" + project.minecraft.version
+archivesBaseName = project.projectDir.name
 
 sourceSets.main{
 	java {

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,16 @@ buildscript {
 	repositories {
 		mavenCentral()
 		maven {
-			name = "forge"
-			url = "http://files.minecraftforge.net/maven"
+			name = "gt"
+			url = "https://gregtech.overminddl1.com/"
 		}
 		maven {
-			name = "sonatype"
-			url = "https://oss.sonatype.org/content/repositories/snapshots/"
+			name = "jitpack"
+			url = "https://jitpack.io"
 		}
 	}
 	dependencies {
-		classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+		classpath "com.github.GTNH2:ForgeGradle:FG_1.2-SNAPSHOT"
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 minecraft_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
+
+tictooltips_version=1.2.6
+
 tcon_version=1.8.4.build941

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.7.10
-forge_version=10.13.3.1384-1.7.10
+forge_version=10.13.4.1614-1.7.10
 tcon_version=1.8.4.build941

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Wed Jul 02 15:54:47 CDT 2014
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/java/squeek/tictooltips/TooltipHandler.java
+++ b/java/squeek/tictooltips/TooltipHandler.java
@@ -459,6 +459,15 @@ public class TooltipHandler
 
 		String damageColor = ColorHelper.getRelativeColor(ToolHelper.getRawDamage(tool, toolTag) + stoneboundDamage, ToolPartHelper.minAttack, ToolPartHelper.maxAttack);
 		toolTip.add(StringHelper.getLocalizedString("gui.toolstation3") + damageColor + StringHelper.getDamageString(damage));
+
+		// For ranged weapons (projectiles and thrown), the base damage is multiplied by the projectile speed to determine total damage.
+		// ToolHelper.getBaseDamage() returns -1 if the tool doesn't use base damage.
+		int baseDamage = ToolHelper.getBaseDamage(tool, toolTag);
+		if (baseDamage >= 0)
+		{
+			String baseDamageColor = ColorHelper.getRelativeColor(baseDamage, ToolPartHelper.minAttack, ToolPartHelper.maxAttack);
+			toolTip.add(StringHelper.getLocalizedString("tictooltips.tool.basedamage") + baseDamageColor + StringHelper.getDamageString(baseDamage));
+		}
 		if (sprintDamage != damage)
 		{
 			String sprintDamageColor = ColorHelper.getRelativeColor(ToolHelper.getRawDamage(tool, toolTag) + stoneboundDamage + (sprintDamage - damage), ToolPartHelper.minAttack, ToolPartHelper.maxAttack);

--- a/java/squeek/tictooltips/helpers/ToolHelper.java
+++ b/java/squeek/tictooltips/helpers/ToolHelper.java
@@ -151,6 +151,17 @@ public class ToolHelper
 		return rawDamage;
 	}
 
+	/** Returns {@code -1} for tools that don't use base attack. */
+	public static int getBaseDamage(ToolCore tool, NBTTagCompound toolTag)
+	{
+		if (tool instanceof AmmoItem && toolTag.hasKey("BaseAttack"))
+		{
+			return toolTag.getInteger("BaseAttack");
+		}
+		else
+			return -1;
+	}
+
 	public static int getDamage(ToolCore tool, NBTTagCompound toolTag, float damageModifier)
 	{
 		return (int) getPreciseDamage(tool, toolTag, damageModifier);

--- a/resources/assets/tictooltips/lang/en_US.lang
+++ b/resources/assets/tictooltips/lang/en_US.lang
@@ -26,6 +26,7 @@ tictooltips.tool.bonus.vs.spiders=Bonus vs Spiders:
 tictooltips.tool.chance.to.behead=Chance to Behead: 
 tictooltips.tool.modifiers=Modifiers:
 tictooltips.tool.knockback=Knockback: 
+tictooltips.tool.basedamage=Base Attack: 
 tictooltips.tool.sprint.damage=Sprint Damage: 
 tictooltips.tool.crit.damage=Crit Damage Bonus: 
 # uses: material.cactus.ability/material.stone.ability, gui.toolstation4/gui.toolstation5


### PR DESCRIPTION
Show the value of the `"BaseAttack"` NBT tag in NEI tooltips. This is useful for getting a feel for how a projectile weapon's damage scales with projectile speed, as well as finding bolts / other projectiles that were affected by the IguanaTweaks bug where replacing a part created a tool with lower damage than it should have.

Depends on:
 * https://github.com/GTNewHorizons/TiC-Tooltips/pull/1